### PR TITLE
Bsulman/lnd/landunit tide fix

### DIFF
--- a/components/elm/src/biogeophys/BalanceCheckMod.F90
+++ b/components/elm/src/biogeophys/BalanceCheckMod.F90
@@ -333,10 +333,12 @@ contains
 #elif (defined MARSH)
              errh2o(c) = endwb(c) - begwb(c) &
                   - (forc_rain_col(c) + forc_snow_col(c)  + qflx_floodc(c) + qflx_irrig(c) &
-                  + qflx_tide(c) & !TAO qflx_tide added
                   - qflx_evap_tot(c) - qflx_surf(c) + qflx_surf_input(c) - qflx_h2osfc_surf(c) &
                   - qflx_qrgwl(c) - qflx_drain(c) - qflx_drain_perched(c) - qflx_snwcp_ice(c)  &
-                  + qflx_lat_aqu(c)) * dtime
+                  ) * dtime
+            if (lun_pp%itype(col_pp%landunit(c)) == istsoil .or. lun_pp%itype(col_pp%landunit(c))==istcrop) then
+               errh2o(c) = errh2o(c) - (qflx_tide(c) + qflx_lat_aqu(c)) * dtime
+            endif
 #else
              errh2o(c) = endwb(c) - begwb(c) &
                   - (forc_rain_col(c) + forc_snow_col(c)  + qflx_floodc(c) + qflx_surf_irrig_col(c) + qflx_over_supply_col(c) &

--- a/components/elm/src/biogeophys/SoilHydrologyMod.F90
+++ b/components/elm/src/biogeophys/SoilHydrologyMod.F90
@@ -484,6 +484,8 @@ contains
        do fc = 1, num_hydrologyc
           c = filter_hydrologyc(fc)
           jwt(c) = nlevbed
+          qflx_lat_aqu(c) = 0._r8
+          qflx_tide(c) = 0._r8
           ! allow jwt to equal zero when zwt is in top layer
           do j = 1,nlevbed
              if(zwt(c) <= zi(c,j)) then

--- a/components/elm/src/data_types/ColumnDataType.F90
+++ b/components/elm/src/data_types/ColumnDataType.F90
@@ -5631,7 +5631,7 @@ contains
           ptr_col=this%qflx_drain_vr)
 
 #if (defined HUM_HOL || defined MARSH)
-    this%qflx_lat_aqu(begc:endc) = spval
+    this%qflx_lat_aqu(begc:endc) = 0.0_r8
     call hist_addfld1d (fname='QFLX_LAT_AQU',  units='mm/s',  &
          avgflag='A', long_name='Lateral flow between hummock and hollow', &
          ptr_col=this%qflx_lat_aqu, c2l_scale_type='urbanf')
@@ -5643,7 +5643,7 @@ contains
          ptr_col=this%qflx_lat_aqu_layer)
 
    !SLL added 4/15/21
-   this%qflx_tide(begc:endc) = spval
+   this%qflx_tide(begc:endc) = 0.0_r8
     call hist_addfld1d (fname='QFLX_TIDE',  units='mm H2O/s',  &
          avgflag='A', long_name='Tidal flux between marsh columns', &
          ptr_col=this%qflx_tide)


### PR DESCRIPTION
Fix a crash with non-soil land units and MARSH hydro boundary conditions related to non-initialized water flux values being added in conservation check